### PR TITLE
fix: improve deployment-guard error messages and repository validation

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -467,7 +467,8 @@ jobs:
               echo "❌ Version pattern validation failed"
               echo "   Tag: $TAG"
               echo "   Required pattern: $VERSION_PATTERN"
-              echo "   REASON: Only evergreen date-based versions are allowed (YY.MM.DD where YY >= 25, with optional suffix)"
+              echo "   REASON: Only evergreen date-based versions are allowed"
+              echo "   Accepted formats: YY.MM.DD, YY.MM.DD-N, YY.MM.DD_hash, YY.MM.DD-N_hash (where YY >= 25)"
               echo "false" > /tmp/validation_failed.txt
               continue
             fi
@@ -484,9 +485,15 @@ jobs:
               echo "   Old tag: $OLD_TAG"
               echo "   New tag: $TAG"
 
-              # Remove optional suffix (-1, -2, etc) for version comparison
-              OLD_VERSION="${OLD_TAG%%-*}"
-              NEW_VERSION="${TAG%%-*}"
+              # Extract base version for comparison
+              # Handle formats: YY.MM.DD, YY.MM.DD-N, YY.MM.DD_hash, YY.MM.DD-N_hash
+              # First remove hash (everything after underscore)
+              OLD_VERSION_NO_HASH="${OLD_TAG%%_*}"
+              NEW_VERSION_NO_HASH="${TAG%%_*}"
+
+              # Then remove rebuild number (everything after first dash)
+              OLD_VERSION="${OLD_VERSION_NO_HASH%%-*}"
+              NEW_VERSION="${NEW_VERSION_NO_HASH%%-*}"
 
               # Compare versions (YY.MM.DD format)
               # Convert to comparable format: YYMMDD
@@ -646,7 +653,7 @@ jobs:
               echo "  - Repository: Only images from '${{ inputs.allowed_image_repositories }}' are allowed"
             fi
             echo "  - Version format: Must match pattern '${{ inputs.allowed_version_pattern }}'"
-            echo "    (Evergreen date-based versions only: YY.MM.DD where YY >= 25, with optional suffix)"
+            echo "    (Evergreen date-based versions only: YY.MM.DD, YY.MM.DD-N, YY.MM.DD_hash, YY.MM.DD-N_hash where YY >= 25)"
             if [ "${{ inputs.verify_image_existence }}" = "true" ]; then
               echo "  - Registry existence: Image must exist in the Docker registry"
             fi


### PR DESCRIPTION
## Summary
Improves error messages in deployment-guard workflow for better traceability and fixes repository validation bug when using registry prefixes.

## Changes

### 1. Error Message Improvements (Related to dotCMS/deutschebank-infrastructure#339)
All validation error messages now include:
- Clear "REASON:" prefix explaining why validation failed
- Explicit statement of validation rules
- Removed "how to fix" suggestions (just state the rules)

**Before:**
```
❌ BLOCKED: Modified files are not in the allowlist
Please ensure you're only modifying allowed files.
```

**After:**
```
❌ BLOCKED: File allowlist validation failed

REASON: One or more modified files are not in the allowlist

Validation Rule: Only files matching the following pattern can be modified:
  - Pattern: kubernetes/dotcms/**/statefulset.ya?ml
```

### 2. Bug Fix: Repository Validation with Registry Prefix
Fixed bug where images with registry prefixes (e.g., `mirror.gcr.io/dotcms/dotcms:25.12.11`) would fail repository validation even when the base repository (`dotcms/dotcms`) is in the allowlist.

**The Problem:**
```yaml
# Actual image in statefulset
image: mirror.gcr.io/dotcms/dotcms:25.12.11

# Allowed repositories in caller workflow
allowed_image_repositories: 'dotcms/dotcms'

# Previous behavior: ❌ FAIL - exact match required
# mirror.gcr.io/dotcms/dotcms != dotcms/dotcms
```

**The Solution:**
- Extract base repository name from full image path
- Compare both full repository AND base repository with allowlist
- Handles: `mirror.gcr.io/dotcms/dotcms`, `gcr.io/project/dotcms/dotcms`, `dotcms/dotcms`
- All resolve to base: `dotcms/dotcms` for comparison

**Added Debug Logging:**
```
   Full image: mirror.gcr.io/dotcms/dotcms:25.12.11
   Repository: mirror.gcr.io/dotcms/dotcms
   Tag: 25.12.11
   Comparing 'dotcms/dotcms' with allowed 'dotcms/dotcms'
   ✓ Match found
```

### 3. Improved All Validation Errors
- **File Allowlist**: Clear reason and pattern display
- **Image-Only Changes**: Explicit list of allowed vs not-allowed changes
- **Image Format**: Shows expected format when invalid
- **Repository**: Shows reason for failure and allowed list
- **Version Pattern**: Explains evergreen requirements and shows pattern
- **Registry Existence**: Clear reason when image not found
- **Final Summary**: Lists all validation rules including downgrade prevention

## Testing
Tested with Deutsche Bank infrastructure during Phase 1 testing:
- ✅ Test 1.1: PUBLIC member bypass works
- ✅ Test 1.2: File allowlist blocks correctly
- ✅ Test 1.3: Image-only check detects multiple changes
- ✅ Test 1.4: LTS version rejected
- ✅ Test 1.5: Latest tag rejected
- Identified repository validation bug with `mirror.gcr.io` prefix → Fixed

## Benefits
1. **Traceability**: All errors clearly state WHY validation failed
2. **Compliance**: Error messages suitable for audit purposes
3. **User Experience**: Users understand validation rules without needing documentation
4. **Registry Flexibility**: Supports images from mirror registries without configuration changes

## Breaking Changes
None - this is backward compatible. Existing workflows will continue to work and benefit from improved error messages.

## Related Issues
- dotCMS/deutschebank-infrastructure#339 - Deployment guard implementation and testing

