### PR TITLE
fix: correct repository extraction for mirror registries

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -430,14 +430,10 @@ jobs:
                 #   dotcms/dotcms -> dotcms/dotcms
                 BASE_REPO="$REPO"
                 if [[ "$REPO" =~ / ]]; then
-                  # If REPO contains registry (has multiple slashes or starts with known registries)
-                  if [[ "$REPO" =~ ^[a-z0-9.-]+\.[a-z]{2,}/.*/ ]] || [[ "$REPO" =~ ^gcr\.io/ ]] || [[ "$REPO" =~ ^.*\.gcr\.io/ ]]; then
-                    # Extract everything after the registry domain
+                  # Check if REPO starts with a registry domain
+                  if [[ "$REPO" =~ ^[a-z0-9.-]+\.[a-z]{2,}/ ]] || [[ "$REPO" =~ ^gcr\.io/ ]] || [[ "$REPO" =~ ^.*\.gcr\.io/ ]]; then
+                    # Extract everything after the first slash (removes registry domain)
                     BASE_REPO="${REPO#*/}"
-                    # If there are still slashes, get the last two parts (org/repo)
-                    if [[ "$BASE_REPO" =~ / ]]; then
-                      BASE_REPO="${BASE_REPO#*/}"
-                    fi
                   fi
                 fi
 


### PR DESCRIPTION
## Summary

Fixes the repository extraction logic that was incorrectly removing too much from mirror registry paths.

## Problem

The previous logic performed two extractions:
1. `mirror.gcr.io/dotcms/dotcms` → `dotcms/dotcms` (remove registry)
2. `dotcms/dotcms` → `dotcms` (remove one more level)

This caused validation failures because `dotcms` does not match the allowed repository `dotcms/dotcms`.

## Solution

Changed to a single extraction that removes only the registry domain prefix, preserving the org/repo structure.

### Test Results

- ✅ `mirror.gcr.io/dotcms/dotcms` → `dotcms/dotcms`
- ✅ `docker.io/dotcms/dotcms` → `dotcms/dotcms`
- ✅ `dotcms/dotcms` → `dotcms/dotcms`

## Impact

This fix enables proper validation of images from mirror registries like `mirror.gcr.io`.

## Related

- Blocks: dotCMS/deutschebank-infrastructure#360
- Follows: #13
