### PR TITLE
fix: resolve subshell issue in image validation loop

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -393,7 +393,8 @@ jobs:
           mapfile -t OLD_IMAGES_ARRAY < <(echo "$OLD_IMAGES" | jq -r '.[]')
 
           INDEX=0
-          echo "$NEW_IMAGES" | jq -r '.[]' | while IFS= read -r image; do
+          # Use process substitution to avoid subshell issues with pipe
+          while IFS= read -r image; do
             echo "=================================================="
             echo "Validating image: $image"
             echo "=================================================="
@@ -540,7 +541,7 @@ jobs:
 
             echo "✅ Image validated successfully: $image"
             echo ""
-          done
+          done < <(echo "$NEW_IMAGES" | jq -r '.[]')
 
           if [ -f /tmp/validation_failed.txt ]; then
             echo "result=fail" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The image validation was failing with exit code 1 even when all validation checks passed successfully. This was caused by a bash subshell issue.

## Root Cause

The validation loop used a pipe pattern:
```bash
echo "$NEW_IMAGES" | jq -r '.[]' | while IFS= read -r image; do
  # validation code that writes to /tmp/validation_failed.txt
done
```

This pattern creates a subshell, and files written inside the subshell (`/tmp/validation_failed.txt`) are not visible to the parent shell after the loop completes.

## Solution

Changed to process substitution pattern:
```bash
while IFS= read -r image; do
  # validation code that writes to /tmp/validation_failed.txt
done < <(echo "$NEW_IMAGES" | jq -r '.[]')
```

This runs the loop in the current shell context, allowing file writes to persist correctly.

## Testing

This fix will be validated with test PR #360 in deutschebank-infrastructure repository, which previously showed all checks passing but failed with exit code 1.

## Related

- Fixes validation failure in dotCMS/deutschebank-infrastructure#360