### PR TITLE
fix: resolve second subshell issue in image-only validation

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -286,7 +286,8 @@ jobs:
 
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
 
-          echo "$CHANGED_FILES" | jq -r '.[]' | while IFS= read -r file; do
+          # Use process substitution to avoid subshell issues with pipe
+          while IFS= read -r file; do
             echo "=================================================="
             echo "Validating: $file"
             echo "=================================================="
@@ -330,7 +331,7 @@ jobs:
               echo "$OLD_IMAGE" >> /tmp/old_images.txt
             fi
             echo ""
-          done
+          done < <(echo "$CHANGED_FILES" | jq -r '.[]')
 
           if [ -f /tmp/validation_failed.txt ]; then
             {


### PR DESCRIPTION
## Problem

Found a second subshell issue in the `validate-image-only-changed` step that was causing the same false failure problem.

## Root Cause

The loop checking if only image field changed also used a pipe pattern:
```bash
echo "$CHANGED_FILES" | jq -r '.[]' | while IFS= read -r file; do
  # validation code that writes to /tmp files
done
```

This creates a subshell where file writes don't persist after the loop.

## Solution

Applied the same process substitution fix:
```bash
while IFS= read -r file; do
  # validation code
done < <(echo "$CHANGED_FILES" | jq -r '.[]')
```

## Testing

This will be validated with PR #362 in deutschebank-infrastructure repository.

## Related

- Fixes same issue as dotCMS/ai-workflows#15
- Required for dotCMS/deutschebank-infrastructure#362