### PR TITLE
fix: resolve BASE_REPO variable scope issue

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -417,27 +417,29 @@ jobs:
             echo "   Repository: $REPO"
             echo "   Tag: $TAG"
 
-            # 3. Check repository is in allowlist (if configured)
+            # 3. Extract base repository name (handle both with and without registry prefix)
+            # This is needed for both repository validation and image existence check
+            # Examples:
+            #   mirror.gcr.io/dotcms/dotcms -> dotcms/dotcms
+            #   gcr.io/project/dotcms/dotcms -> dotcms/dotcms
+            #   dotcms/dotcms -> dotcms/dotcms
+            BASE_REPO="$REPO"
+            if [[ "$REPO" =~ / ]]; then
+              # Check if REPO starts with a registry domain
+              if [[ "$REPO" =~ ^[a-z0-9.-]+\.[a-z]{2,}/ ]] || [[ "$REPO" =~ ^gcr\.io/ ]] || [[ "$REPO" =~ ^.*\.gcr\.io/ ]]; then
+                # Extract everything after the first slash (removes registry domain)
+                BASE_REPO="${REPO#*/}"
+              fi
+            fi
+            echo "   Base repository: $BASE_REPO"
+
+            # 4. Check repository is in allowlist (if configured)
             if [ -n "$ALLOWED_REPOS" ]; then
               REPO_ALLOWED=false
               IFS=',' read -ra ALLOWED <<< "$ALLOWED_REPOS"
               for allowed_repo in "${ALLOWED[@]}"; do
                 # Trim whitespace
                 allowed_repo=$(echo "$allowed_repo" | xargs)
-
-                # Extract base repository name (handle both with and without registry prefix)
-                # Examples:
-                #   mirror.gcr.io/dotcms/dotcms -> dotcms/dotcms
-                #   gcr.io/project/dotcms/dotcms -> dotcms/dotcms
-                #   dotcms/dotcms -> dotcms/dotcms
-                BASE_REPO="$REPO"
-                if [[ "$REPO" =~ / ]]; then
-                  # Check if REPO starts with a registry domain
-                  if [[ "$REPO" =~ ^[a-z0-9.-]+\.[a-z]{2,}/ ]] || [[ "$REPO" =~ ^gcr\.io/ ]] || [[ "$REPO" =~ ^.*\.gcr\.io/ ]]; then
-                    # Extract everything after the first slash (removes registry domain)
-                    BASE_REPO="${REPO#*/}"
-                  fi
-                fi
 
                 echo "   Comparing '$BASE_REPO' with allowed '$allowed_repo'"
                 if [[ "$BASE_REPO" == "$allowed_repo" ]] || [[ "$REPO" == "$allowed_repo" ]]; then
@@ -460,7 +462,7 @@ jobs:
               echo "ℹ️  Repository validation skipped (no allowlist configured)"
             fi
 
-            # 4. Validate tag matches version pattern
+            # 5. Validate tag matches version pattern
             if ! [[ "$TAG" =~ $VERSION_PATTERN ]]; then
               echo "❌ Version pattern validation failed"
               echo "   Tag: $TAG"
@@ -472,7 +474,7 @@ jobs:
             fi
             echo "✅ Tag matches version pattern"
 
-            # 4.5. Anti-downgrade validation (compare versions)
+            # 6. Anti-downgrade validation (compare versions)
             # Get the corresponding old image by index
             OLD_IMAGE="${OLD_IMAGES_ARRAY[$INDEX]}"
             if [ -n "$OLD_IMAGE" ]; then
@@ -517,7 +519,7 @@ jobs:
             # Increment index for next iteration
             ((INDEX++))
 
-            # 5. Verify image exists in Docker Hub (canonical registry)
+            # 7. Verify image exists in Docker Hub (canonical registry)
             if [ "$VERIFY_EXISTENCE" = "true" ]; then
               # Use canonical image (without registry prefix) to verify in Docker Hub
               # This assumes mirror registries have the same images as Docker Hub


### PR DESCRIPTION
## Problem

The `BASE_REPO` variable was only defined inside the repository allowlist validation block (step 3), but it was being used later in the image existence check (step 5). This caused the variable to be empty when `verify_image_existence` was enabled, leading to validation failures.

## Root Cause

In the image validation loop:
- `BASE_REPO` extraction logic was inside the `if [ -n "$ALLOWED_REPOS" ]` block (lines 433-440)
- The image existence check at line 524 used `CANONICAL_IMAGE="${BASE_REPO}:${TAG}"`
- When `ALLOWED_REPOS` was set, `BASE_REPO` was defined and everything worked
- However, the variable was being used outside its scope, which is a logic error

## Solution

- **Move BASE_REPO extraction logic** outside the conditional block (before step 4)
- Now `BASE_REPO` is always available for both repository validation and image existence check
- Update step numbering in comments: steps 4-7 instead of 3-5
- Add explicit logging of `BASE_REPO` value for debugging

## Changes

```diff
# 2. Extract repository and tag
REPO="${image%:*}"
TAG="${image##*:}"

+# 3. Extract base repository name (always, needed for multiple validations)
+BASE_REPO="$REPO"
+if [[ "$REPO" =~ / ]]; then
+  if [[ "$REPO" =~ ^[a-z0-9.-]+\.[a-z]{2,}/ ]] || [[ "$REPO" =~ ^gcr\.io/ ]] || [[ "$REPO" =~ ^.*\.gcr\.io/ ]]; then
+    BASE_REPO="${REPO#*/}"
+  fi
+fi
+echo "   Base repository: $BASE_REPO"
+
-# 3. Check repository is in allowlist (if configured)
+# 4. Check repository is in allowlist (if configured)
if [ -n "$ALLOWED_REPOS" ]; then
-  BASE_REPO="$REPO"  # ← Was only defined here
-  if [[ "$REPO" =~ / ]]; then
-    ...
-  fi
  ...
fi
```

## Testing

This fixes the validation failure in [PR #362](https://github.com/dotCMS/deutschebank-infrastructure/pull/362) where the image existence check was failing due to empty `BASE_REPO` variable.

After this fix is merged and v1.1.1 tag is recreated, PR #362 should pass all validations.

## Related

- Fixes issue discovered in deutschebank-infrastructure PR #362
- Related to #15 (subshell fixes)
- Related to #16 (second subshell fix)