### PR TITLE
fix: cleanup temp files to resolve Bug #1 and Bug #2

### DIFF
--- a/.github/workflows/deployment-guard.yml
+++ b/.github/workflows/deployment-guard.yml
@@ -208,6 +208,9 @@ jobs:
       - name: Check files against allowlist
         id: check-files
         run: |
+          # Clean temp files from any previous runs
+          rm -f /tmp/disallowed_files.txt
+
           CHANGED_FILES='${{ steps.get-files.outputs.files }}'
           ALLOWED_PATTERN='${{ inputs.allowed_files_pattern }}'
 
@@ -273,6 +276,9 @@ jobs:
       - name: Check only image field changed
         id: check-changes
         run: |
+          # Clean temp files from any previous runs
+          rm -f /tmp/validation_failed.txt /tmp/new_images.txt /tmp/old_images.txt
+
           CHANGED_FILES='${{ needs.validate-changed-files.outputs.changed-files }}'
 
           if [ "$CHANGED_FILES" = "" ] || [ "$CHANGED_FILES" = "[]" ]; then
@@ -377,6 +383,9 @@ jobs:
       - name: Validate image format, repository, tag, and existence
         id: validate
         run: |
+          # Clean temp files from any previous runs
+          rm -f /tmp/validation_failed.txt
+
           NEW_IMAGES='${{ needs.validate-image-only-changed.outputs.new-images }}'
           OLD_IMAGES='${{ needs.validate-image-only-changed.outputs.old-images }}'
           ALLOWED_REPOS='${{ inputs.allowed_image_repositories }}'


### PR DESCRIPTION
## Bug Fixes: Temp File Cleanup (Bug #1 and Bug #2)

Fixes critical bugs by adding explicit cleanup of temp files at the start of each job.

**Root Cause:** /tmp directory persists between jobs in GitHub Actions.

**Bugs Fixed:**
- Bug #1: Exit code 1 on successful validations (Test Cases #1, #2)
- Bug #2: Wrong image processed (Test Case #6)

**Solution:** Add `rm -f` cleanup at start of each step using temp files.

---
Will recreate tag v1.1.1 after merge to avoid changing caller workflows.