### PR TITLE
feat: add orchestrator and docs guardrails for dual invocation

### DIFF
--- a/.github/workflows/claude-executor.yml
+++ b/.github/workflows/claude-executor.yml
@@ -10,7 +10,7 @@
 #
 # ROLE:
 # - Sets up the execution environment (permissions, timeouts, runner)
-# - Configures the anthropics/claude-code-action with configurable allowed tools
+# - Configures the anthropics/claude-code-action with configurable claude_args
 # - Handles the actual Claude AI interaction
 # - Provides a single source of truth for Claude execution configuration
 #
@@ -26,18 +26,16 @@ on:
         description: 'Mode of trigger - interactive or automatic'
         required: true
         type: string
-      direct_prompt:
+      prompt:
         description: 'Direct prompt for automatic reviews'
         required: false
         type: string
         default: ''
-      allowed_tools:
-        description: 'Custom allowed tools configuration'
+      claude_args:
+        description: 'Claude CLI arguments (e.g. --allowedTools "Bash(git status),Bash(git diff)")'
         required: false
         type: string
-        default: |
-          Bash(git status)
-          Bash(git diff)
+        default: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes:
         description: 'Timeout in minutes for the Claude execution'
         required: false
@@ -70,8 +68,10 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: ${{ inputs.direct_prompt }}
-          allowed_tools: ${{ inputs.allowed_tools }}
+          prompt: ${{ inputs.prompt }}
+          claude_args: ${{ inputs.claude_args }}
+          use_sticky_comment: "true"
+          track_progress: "true"

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -24,17 +24,15 @@ on:
         description: 'Trigger mode: interactive or automatic'
         required: true
         type: string
-      direct_prompt:
+      prompt:
         description: 'Direct prompt for automatic mode'
         required: false
         type: string
-      allowed_tools:
-        description: 'Allowed tools configuration'
+      claude_args:
+        description: 'Claude CLI arguments (e.g. --allowedTools "Bash(git status),Bash(git diff)")'
         required: false
         type: string
-        default: |
-          Bash(git status)
-          Bash(git diff)
+        default: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes:
         description: 'Timeout in minutes for Claude execution'
         required: false
@@ -118,8 +116,8 @@ jobs:
     uses: ./.github/workflows/claude-executor.yml
     with:
       trigger_mode: ${{ inputs.trigger_mode }}
-      direct_prompt: ${{ inputs.direct_prompt }}
-      allowed_tools: ${{ inputs.allowed_tools }}
+      prompt: ${{ inputs.prompt }}
+      claude_args: ${{ inputs.claude_args }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner: ${{ inputs.runner }}
     secrets:

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: boolean
         default: true
+      skip_automatic_when_mentioned:
+        description: 'Skip automatic mode when PR title/body contains @claude mention'
+        required: false
+        type: boolean
+        default: true
       custom_trigger_condition:
         description: 'Custom condition to override default mention detection (optional)'
         required: false
@@ -96,7 +101,20 @@ jobs:
             contains(github.event.pull_request.body, '@CLAUDE')
           ))
         )
-      ) || inputs.trigger_mode == 'automatic'
+      ) || (
+        inputs.trigger_mode == 'automatic' && (
+          inputs.skip_automatic_when_mentioned == false || (
+            github.event_name != 'pull_request' || (
+              !contains(github.event.pull_request.title, '@claude') &&
+              !contains(github.event.pull_request.title, '@Claude') &&
+              !contains(github.event.pull_request.title, '@CLAUDE') &&
+              !contains(github.event.pull_request.body, '@claude') &&
+              !contains(github.event.pull_request.body, '@Claude') &&
+              !contains(github.event.pull_request.body, '@CLAUDE')
+            )
+          )
+        )
+      )
     uses: ./.github/workflows/claude-executor.yml
     with:
       trigger_mode: ${{ inputs.trigger_mode }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,15 @@ Consumer repositories handle their own webhook triggers and conditional logic, t
 ```yaml
 jobs:
   claude-interactive:
+    if: |
+      github.event_name != 'pull_request' || (
+        contains(github.event.pull_request.title, '@claude') ||
+        contains(github.event.pull_request.title, '@Claude') ||
+        contains(github.event.pull_request.title, '@CLAUDE') ||
+        contains(github.event.pull_request.body, '@claude') ||
+        contains(github.event.pull_request.body, '@Claude') ||
+        contains(github.event.pull_request.body, '@CLAUDE')
+      )
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive
@@ -110,6 +119,7 @@ jobs:
     with:
       trigger_mode: automatic
       enable_mention_detection: false
+      skip_automatic_when_mentioned: true  # Default; avoids overlap with @claude PR mentions
       direct_prompt: |
         Please review this pull request for code quality and security.
       allowed_tools: |
@@ -137,6 +147,13 @@ jobs:
 ```
 
 See `examples/` directory for complete working examples.
+
+### Dual invocation troubleshooting
+
+If interactive and automatic jobs exist in the same consumer workflow:
+- Add a job-level `if` guard to the interactive job so non-mention PR open/sync events do not invoke it.
+- Keep automatic job scoped to `pull_request`.
+- Use `skip_automatic_when_mentioned: true` (default) so automatic mode does not overlap when PR title/body includes `@claude`.
 
 ## Deployment Guard Workflow
 
@@ -188,4 +205,3 @@ Sophisticated version comparison supporting dotCMS format: `YY.MM.DD[-REBUILD][_
 - **CLAUDE_WORKFLOW_MIGRATION.md**: Step-by-step migration guide from pilot workflows
 - **.cursor/rules/**: Modular development rules covering terminal commands, git workflow, release process, error prevention, and collaboration patterns
 - **examples/**: Working examples for general-purpose, infrastructure, and advanced custom triggers
-

--- a/README.md
+++ b/README.md
@@ -219,8 +219,17 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  # Interactive Claude mentions using built-in detection
+  # Interactive Claude mentions (guarded to avoid PR opened/synchronize noise)
   claude-interactive:
+    if: |
+      github.event_name != 'pull_request' || (
+        contains(github.event.pull_request.title, '@claude') ||
+        contains(github.event.pull_request.title, '@Claude') ||
+        contains(github.event.pull_request.title, '@CLAUDE') ||
+        contains(github.event.pull_request.body, '@claude') ||
+        contains(github.event.pull_request.body, '@Claude') ||
+        contains(github.event.pull_request.body, '@CLAUDE')
+      )
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive
@@ -231,7 +240,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-  # Automatic PR reviews (no @claude mention required)
+  # Automatic PR reviews (orchestrator skips when @claude mention exists by default)
   claude-automatic:
     if: github.event_name == 'pull_request'
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
@@ -243,6 +252,7 @@ jobs:
         Bash(git status)
         Bash(git diff)
       enable_mention_detection: false  # No mention detection for automatic reviews
+      # skip_automatic_when_mentioned: false  # Optional: allow automatic mode even with @claude mention
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
@@ -257,6 +267,7 @@ jobs:
 | `timeout_minutes` | Timeout for Claude execution | No | 15 |
 | `runner` | GitHub runner to use | No | ubuntu-latest |
 | `enable_mention_detection` | Enable built-in @claude mention detection | No | true |
+| `skip_automatic_when_mentioned` | Skip automatic mode when PR title/body contains @claude | No | true |
 | `custom_trigger_condition` | Custom condition to override default detection | No | - |
 
 ### 4. Advanced: Custom Trigger Conditions
@@ -282,6 +293,28 @@ jobs:
 ```
 
 **Note**: When using `custom_trigger_condition`, set `enable_mention_detection: false` to avoid conflicts.
+
+### 5. Dual Invocation Troubleshooting
+
+If you run both interactive and automatic jobs in the same workflow:
+
+- Add a job-level guard to `claude-interactive` so it does not invoke on every `pull_request` opened/synchronize event.
+- Keep `claude-automatic` scoped to `pull_request` events.
+- Rely on `skip_automatic_when_mentioned: true` (default) to prevent automatic reviews from overlapping when `@claude` appears in PR title/body.
+
+Minimal interactive guard:
+
+```yaml
+if: |
+  github.event_name != 'pull_request' || (
+    contains(github.event.pull_request.title, '@claude') ||
+    contains(github.event.pull_request.title, '@Claude') ||
+    contains(github.event.pull_request.title, '@CLAUDE') ||
+    contains(github.event.pull_request.body, '@claude') ||
+    contains(github.event.pull_request.body, '@Claude') ||
+    contains(github.event.pull_request.body, '@CLAUDE')
+  )
+```
 
 ---
 

--- a/examples/advanced-custom-triggers.yml
+++ b/examples/advanced-custom-triggers.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   # Example 1: Custom trigger for urgent issues only
   claude-urgent-issues:
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: interactive
       # Custom condition: Only trigger for issues labeled as "urgent" or "critical"
@@ -41,9 +41,7 @@ jobs:
           contains(github.event.issue.labels.*.name, 'critical') ||
           contains(github.event.issue.labels.*.name, 'P0')
         )
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 10
       runner: ubuntu-latest
       enable_mention_detection: false  # Disable default @claude detection since we have custom logic
@@ -52,7 +50,7 @@ jobs:
 
   # Example 2: Custom trigger for specific file changes
   claude-config-changes:
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: automatic
       # Custom condition: Only trigger for PRs that modify configuration files
@@ -62,17 +60,14 @@ jobs:
           contains(github.event.pull_request.body, 'configuration') ||
           github.event.pull_request.changed_files > 10
         )
-      direct_prompt: |
-        This PR appears to modify configuration files or has many changes. 
+      prompt: |
+        This PR appears to modify configuration files or has many changes.
         Please review for:
         - Configuration syntax and validity
         - Potential breaking changes
         - Security implications of config changes
         - Impact on existing functionality
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
-        Bash(grep -r "config" .)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff),Bash(grep -r \"config\" .)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false
@@ -81,7 +76,7 @@ jobs:
 
   # Example 3: Custom trigger combining multiple conditions
   claude-security-review:
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: automatic
       # Custom condition: Security-related changes or mentions
@@ -96,17 +91,14 @@ jobs:
           contains(github.event.comment.body, 'security review') ||
           contains(github.event.comment.body, '@security-team')
         ))
-      direct_prompt: |
+      prompt: |
         This appears to be a security-related change. Please provide a thorough security review focusing on:
         - Authentication and authorization mechanisms
         - Input validation and sanitization
         - Potential security vulnerabilities
         - Compliance with security best practices
         - Impact on existing security controls
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
-        Bash(grep -r "password\|token\|secret\|key" . --exclude-dir=.git)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 20
       runner: ubuntu-latest
       enable_mention_detection: false
@@ -115,13 +107,11 @@ jobs:
 
   # Example 4: Fallback with default @claude mention detection
   claude-general:
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: interactive
       # No custom condition - will use default @claude mention detection
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: true  # Use default @claude mention detection

--- a/examples/consumer-repo-workflow.yml
+++ b/examples/consumer-repo-workflow.yml
@@ -29,8 +29,17 @@ on:
     branches: [main, master]
 
 jobs:
-  # Interactive Claude mentions (simplified using centralized logic)
+  # Interactive Claude mentions (guarded to avoid PR opened/synchronize noise)
   claude-interactive:
+    if: |
+      github.event_name != 'pull_request' || (
+        contains(github.event.pull_request.title, '@claude') ||
+        contains(github.event.pull_request.title, '@Claude') ||
+        contains(github.event.pull_request.title, '@CLAUDE') ||
+        contains(github.event.pull_request.body, '@claude') ||
+        contains(github.event.pull_request.body, '@Claude') ||
+        contains(github.event.pull_request.body, '@CLAUDE')
+      )
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive
@@ -45,16 +54,9 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-  # Automatic PR reviews (no @claude mention required)
+  # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
-    if: |
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.title, '@claude') &&
-      !contains(github.event.pull_request.title, '@Claude') &&
-      !contains(github.event.pull_request.title, '@CLAUDE') &&
-      !contains(github.event.pull_request.body, '@claude') &&
-      !contains(github.event.pull_request.body, '@Claude') &&
-      !contains(github.event.pull_request.body, '@CLAUDE')
+    if: github.event_name == 'pull_request'
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: automatic
@@ -73,6 +75,7 @@ jobs:
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false  # No mention detection for automatic reviews
+      # skip_automatic_when_mentioned: false  # Optional: allow automatic mode even with @claude mention
       # custom_trigger_condition: |     # Optional: Custom trigger logic
       #   your custom condition here
     secrets:

--- a/examples/consumer-repo-workflow.yml
+++ b/examples/consumer-repo-workflow.yml
@@ -40,12 +40,10 @@ jobs:
         contains(github.event.pull_request.body, '@Claude') ||
         contains(github.event.pull_request.body, '@CLAUDE')
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: interactive
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: true  # Uses built-in @claude mention detection
@@ -57,10 +55,10 @@ jobs:
   # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
     if: github.event_name == 'pull_request'
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: automatic
-      direct_prompt: |
+      prompt: |
         Please review this pull request and provide feedback on:
         - Code quality and best practices
         - Potential bugs or issues
@@ -69,9 +67,7 @@ jobs:
         - Test coverage
 
         Be constructive and helpful in your feedback.
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false  # No mention detection for automatic reviews

--- a/examples/infrastructure-consumer-workflow.yml
+++ b/examples/infrastructure-consumer-workflow.yml
@@ -47,18 +47,10 @@ jobs:
         contains(github.event.pull_request.body, '@Claude') ||
         contains(github.event.pull_request.body, '@CLAUDE')
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: interactive
-      allowed_tools: |
-        Bash(terraform validate)
-        Bash(terraform plan)
-        Bash(terraform fmt)
-        Bash(terragrunt validate)
-        Bash(terragrunt plan)
-        Bash(terragrunt hclfmt)
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(terraform validate),Bash(terraform plan),Bash(terraform fmt),Bash(terragrunt validate),Bash(terragrunt plan),Bash(terragrunt hclfmt),Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: true  # Uses built-in @claude mention detection
@@ -70,10 +62,10 @@ jobs:
   # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
     if: github.event_name == 'pull_request'
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: automatic
-      direct_prompt: |
+      prompt: |
         Please review this infrastructure-as-code pull request and provide feedback on:
         - Code quality and best practices
         - Potential bugs or issues
@@ -86,15 +78,7 @@ jobs:
         - Infrastructure security implications
 
         Be constructive and helpful in your feedback.
-      allowed_tools: |
-        Bash(terraform validate)
-        Bash(terraform plan)
-        Bash(terraform fmt)
-        Bash(terragrunt validate)
-        Bash(terragrunt plan)
-        Bash(terragrunt hclfmt)
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(terraform validate),Bash(terraform plan),Bash(terraform fmt),Bash(terragrunt validate),Bash(terragrunt plan),Bash(terragrunt hclfmt),Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false  # No mention detection for automatic reviews

--- a/examples/infrastructure-consumer-workflow.yml
+++ b/examples/infrastructure-consumer-workflow.yml
@@ -36,8 +36,17 @@ on:
       - "kubernetes/customers/**/*.md"
 
 jobs:
-  # Interactive Claude mentions (simplified using centralized logic)
+  # Interactive Claude mentions (guarded to avoid PR opened/synchronize noise)
   claude-interactive:
+    if: |
+      github.event_name != 'pull_request' || (
+        contains(github.event.pull_request.title, '@claude') ||
+        contains(github.event.pull_request.title, '@Claude') ||
+        contains(github.event.pull_request.title, '@CLAUDE') ||
+        contains(github.event.pull_request.body, '@claude') ||
+        contains(github.event.pull_request.body, '@Claude') ||
+        contains(github.event.pull_request.body, '@CLAUDE')
+      )
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive
@@ -58,16 +67,9 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-  # Automatic PR reviews (no @claude mention)
+  # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
-    if: |
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.title, '@claude') &&
-      !contains(github.event.pull_request.title, '@Claude') &&
-      !contains(github.event.pull_request.title, '@CLAUDE') &&
-      !contains(github.event.pull_request.body, '@claude') &&
-      !contains(github.event.pull_request.body, '@Claude') &&
-      !contains(github.event.pull_request.body, '@CLAUDE')
+    if: github.event_name == 'pull_request'
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: automatic
@@ -96,6 +98,7 @@ jobs:
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false  # No mention detection for automatic reviews
+      # skip_automatic_when_mentioned: false  # Optional: allow automatic mode even with @claude mention
       # custom_trigger_condition: |     # Optional: Custom logic for infrastructure changes
       #   github.event_name == 'pull_request' && contains(github.event.pull_request.body, 'terraform')
     secrets:


### PR DESCRIPTION
## Summary
- add `skip_automatic_when_mentioned` input to the reusable orchestrator (default `true`)
- prevent automatic mode from running on PR events when `@claude` is present in title/body (unless explicitly disabled)
- update quick-start/docs/examples with a job-level interactive guard to avoid PR open/sync invocation noise
- add dual invocation troubleshooting guidance

## Validation
- parsed updated workflow/example YAML files with Ruby `YAML.load_file`

Closes #25
