### PR TITLE
feat(claude): allow the claude bot to trigger AI reviews

### DIFF
--- a/.github/workflows/claude-executor.yml
+++ b/.github/workflows/claude-executor.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: 'us-east-1'
+      allowed_bots:
+        description: 'Comma-separated bot usernames allowed to trigger the action, or "*" for all bots. Defaults to "claude" so the Claude Code GitHub App can trigger reviews; pass "" to block all bots.'
+        required: false
+        type: string
+        default: 'claude'
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key — required when provider=anthropic-api, ignored otherwise'
@@ -185,6 +190,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ inputs.prompt }}
           claude_args: ${{ steps.args.outputs.composed }}
+          allowed_bots: ${{ inputs.allowed_bots }}
           use_sticky_comment: "true"
           track_progress: "true"
 
@@ -197,6 +203,7 @@ jobs:
           use_bedrock: "true"
           prompt: ${{ inputs.prompt }}
           claude_args: ${{ steps.args.outputs.composed }}
+          allowed_bots: ${{ inputs.allowed_bots }}
           use_sticky_comment: "true"
           track_progress: "true"
         env:

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -82,6 +82,11 @@ on:
         required: false
         type: string
         default: ''
+      allowed_bots:
+        description: 'Comma-separated bot usernames allowed to trigger the action, or "*" for all bots. Defaults to "claude" so the Claude Code GitHub App can trigger reviews; pass "" to block all bots. Applies to the Anthropic path only.'
+        required: false
+        type: string
+        default: 'claude'
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key — required only when using the direct Anthropic API path (model_id empty)'
@@ -186,6 +191,7 @@ jobs:
       model_id: ${{ inputs.model_id }}
       bedrock_role_arn: ${{ inputs.bedrock_role_arn }}
       aws_region: ${{ inputs.aws_region }}
+      allowed_bots: ${{ inputs.allowed_bots }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,7 @@ Sophisticated version comparison supporting dotCMS format: `YY.MM.DD[-REBUILD][_
 - **Default Tools**: `git status` and `git diff`
 - **Mention Detection**: Case-insensitive @claude in comments, reviews, issues, and PRs
 - **Concurrency**: Consumer repositories should implement concurrency control to prevent duplicate runs
+- **Allowed Bots**: `allowed_bots` defaults to `claude`, so the Claude Code GitHub App can trigger reviews on PRs/pushes it initiates. `claude-code-action` otherwise blocks bot-initiated runs. Pass `allowed_bots: ""` to block all bots, or `"*"` to allow any (e.g. dependabot, renovate). Applies to the Anthropic path only.
 
 ### Deployment Guard
 - **Organization bypass**: Disabled by default (must configure `trusted_organization`)


### PR DESCRIPTION
## Problem

Bot-initiated auto-reviews fail at the `anthropics/claude-code-action@v1` gate with:

> Action failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

Example: dotCMS/infrastructure-as-code run [27365580499](https://github.com/dotCMS/infrastructure-as-code/actions/runs/27365580499) — a PR whose triggering push came from the Claude Code GitHub App (actor `claude`, type `Bot`). Since Claude is our daily driver, these runs should be reviewed, not blocked.

`allowed_bots` is a dedicated input to `claude-code-action` (not a `claude_args` CLI flag), so it was previously unreachable through the orchestrator/executor and defaulted to "no bots allowed."

## Change

- Add an `allowed_bots` input to **claude-orchestrator.yml** and **claude-executor.yml**.
- Pass it to both `claude-code-action` steps in the executor (Anthropic API + Bedrock paths).
- Default it to **`claude`** org-wide, so the Claude Code GitHub App can trigger reviews on every consumer repo without per-repo config.
- Consumers can override: `allowed_bots: ""` to block all bots, or `allowed_bots: "*"` to allow any (e.g. dependabot, renovate).

Anthropic path only — the bedrock-generic executor does not use `claude-code-action` and has no such gate.

## Rollout

Consumers pinned at `@v3.0.0` pick this up after a new tag (e.g. `v3.1.0`) is cut and their pin is bumped. A follow-up PR bumps the pin in `dotCMS/infrastructure-as-code`.

## Validation

- `yaml.safe_load` passes on both workflows.
- `actionlint` (rhysd/actionlint:1.7.7) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)