### PR TITLE
feat(executors): configurable max_output_tokens + raise generic default to 32000

### DIFF
--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -55,7 +55,7 @@ on:
         description: 'Maximum tokens the model may emit. For reasoning models (e.g. DeepSeek R1) this budget also covers reasoning tokens, so it must be large enough that the answer still fits after thinking.'
         required: false
         type: number
-        default: 16000
+        default: 32000
       timeout_minutes:
         description: 'Job timeout in minutes'
         required: false

--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -52,10 +52,10 @@ on:
         type: number
         default: 80000
       max_output_tokens:
-        description: 'Maximum tokens the model may emit'
+        description: 'Maximum tokens the model may emit. For reasoning models (e.g. DeepSeek R1) this budget also covers reasoning tokens, so it must be large enough that the answer still fits after thinking.'
         required: false
         type: number
-        default: 2048
+        default: 16000
       timeout_minutes:
         description: 'Job timeout in minutes'
         required: false

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -87,6 +87,11 @@ on:
         required: false
         type: string
         default: 'medium'
+      max_output_tokens:
+        description: 'Max output-token budget for the bedrock-generic and OpenAI/Codex paths. For reasoning models this budget also covers reasoning tokens. Ignored on the Anthropic path (it manages its own budget).'
+        required: false
+        type: number
+        default: 16000
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key — required only when using the direct Anthropic API path (model_id empty)'
@@ -209,6 +214,7 @@ jobs:
       aws_region: ${{ inputs.aws_region }}
       prompt: ${{ inputs.prompt }}
       sticky_namespace: ${{ inputs.sticky_namespace }}
+      max_output_tokens: ${{ inputs.max_output_tokens }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner: ${{ inputs.runner }}
 
@@ -225,5 +231,6 @@ jobs:
       prompt: ${{ inputs.prompt }}
       sticky_namespace: ${{ inputs.sticky_namespace }}
       reasoning_effort: ${{ inputs.reasoning_effort }}
+      max_output_tokens: ${{ inputs.max_output_tokens }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner: ${{ inputs.runner }}

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -91,7 +91,7 @@ on:
         description: 'Max output-token budget for the bedrock-generic and OpenAI/Codex paths. For reasoning models this budget also covers reasoning tokens. Ignored on the Anthropic path (it manages its own budget).'
         required: false
         type: number
-        default: 16000
+        default: 32000
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key — required only when using the direct Anthropic API path (model_id empty)'


### PR DESCRIPTION
## What

Make the model output-token budget configurable through the orchestrator, and raise the bedrock-generic default so reasoning-model reviews stop getting truncated.

## Why

`bedrock-generic-executor` capped output at **2048** tokens with no way for orchestrator consumers (e.g. `dotCMS/core`, which routes `us.deepseek.r1-v1:0` through this path) to override it. For reasoning models the budget also covers **reasoning** tokens, so the model could spend most of 2048 thinking and emit a half-finished review.

## Changes

- **bedrock-generic-executor**: default `max_output_tokens` `2048` → `32000`; description now notes reasoning tokens count against the budget.
- **claude-orchestrator**: new `max_output_tokens` input (default `32000`), forwarded to the **bedrock-generic** and **codex-mantle** paths. The Anthropic path manages its own budget and ignores it.

## Override example

```yaml
uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.6
with:
  model_id: us.deepseek.r1-v1:0
  max_output_tokens: 24000   # optional; defaults to 32000
```

## Compatibility

Additive and backward-compatible — new optional input; only the generic-path default cap changed (raised, never lowered). Anthropic path unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
