### PR TITLE
feat(orchestrator): optional use_sticky_comment input to disable sticky comments

### DIFF
--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ''
+      use_sticky_comment:
+        description: 'Reuse one auto-updating comment per PR (true, default). Set false to post a fresh comment on every run, preserving the full feedback->change->feedback history for reviewers.'
+        required: false
+        type: boolean
+        default: true
       max_diff_chars:
         description: 'Maximum diff length to send to the model (chars). Larger diffs are truncated at a line boundary.'
         required: false
@@ -85,6 +90,7 @@ jobs:
       # default uses the model family so different models naturally get
       # different stickies.
       STICKY_MARKER: ${{ format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
+      USE_STICKY: ${{ inputs.use_sticky_comment }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -106,8 +112,10 @@ jobs:
           cat > /tmp/sticky-comment.sh <<'STICKY_EOF'
           #!/usr/bin/env bash
           # Find-or-update a single PR comment identified by STICKY_MARKER.
+          # When USE_STICKY=false, always post a fresh comment (skip the lookup) so the
+          # full feedback->change->feedback history stays visible to reviewers.
           # Usage: sticky-comment.sh <pr_number> <body_file>
-          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER
+          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER, USE_STICKY (default true)
           set -euo pipefail
           PR_NUMBER="${1:?pr number required}"
           BODY_FILE="${2:?body file required}"
@@ -115,12 +123,16 @@ jobs:
           : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
           : "${STICKY_MARKER:?STICKY_MARKER must be set}"
           [ -r "$BODY_FILE" ] || { echo "Body file not readable: $BODY_FILE" >&2; exit 1; }
-          EXISTING_ID=$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-              | jq -r --arg marker "$STICKY_MARKER" \
-                  '.[] | select(.body | startswith($marker)) | .id' \
-              | head -1
-          )
+          if [ "${USE_STICKY:-true}" = "true" ]; then
+            EXISTING_ID=$(
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+                | jq -r --arg marker "$STICKY_MARKER" \
+                    '.[] | select(.body | startswith($marker)) | .id' \
+                | head -1
+            )
+          else
+            EXISTING_ID=""
+          fi
           if [ -n "$EXISTING_ID" ] && ! [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
             echo "::warning::EXISTING_ID is non-numeric ($EXISTING_ID); creating a new comment instead"
             EXISTING_ID=""

--- a/.github/workflows/claude-executor.yml
+++ b/.github/workflows/claude-executor.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: 'us-east-1'
+      use_sticky_comment:
+        description: 'Reuse one auto-updating comment per PR (true, default). Set false to post a fresh comment on every run, preserving the full feedback history.'
+        required: false
+        type: boolean
+        default: true
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key — required when provider=anthropic-api, ignored otherwise'
@@ -185,7 +190,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ inputs.prompt }}
           claude_args: ${{ steps.args.outputs.composed }}
-          use_sticky_comment: "true"
+          use_sticky_comment: ${{ inputs.use_sticky_comment }}
           track_progress: "true"
 
       - name: Run Claude Code (Bedrock)
@@ -197,7 +202,7 @@ jobs:
           use_bedrock: "true"
           prompt: ${{ inputs.prompt }}
           claude_args: ${{ steps.args.outputs.composed }}
-          use_sticky_comment: "true"
+          use_sticky_comment: ${{ inputs.use_sticky_comment }}
           track_progress: "true"
         env:
           AWS_REGION: ${{ inputs.aws_region }}

--- a/.github/workflows/claude-orchestrator.yml
+++ b/.github/workflows/claude-orchestrator.yml
@@ -82,6 +82,11 @@ on:
         required: false
         type: string
         default: ''
+      use_sticky_comment:
+        description: 'Reuse one auto-updating comment per PR (true, default). Set false to post a fresh comment on every run, preserving the full feedback->change->feedback history for reviewers.'
+        required: false
+        type: boolean
+        default: true
       reasoning_effort:
         description: 'Reasoning effort for the OpenAI/Codex (mantle) path: minimal | low | medium | high. Ignored on other paths.'
         required: false
@@ -201,6 +206,7 @@ jobs:
       model_id: ${{ inputs.model_id }}
       bedrock_role_arn: ${{ inputs.bedrock_role_arn }}
       aws_region: ${{ inputs.aws_region }}
+      use_sticky_comment: ${{ inputs.use_sticky_comment }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -214,6 +220,7 @@ jobs:
       aws_region: ${{ inputs.aws_region }}
       prompt: ${{ inputs.prompt }}
       sticky_namespace: ${{ inputs.sticky_namespace }}
+      use_sticky_comment: ${{ inputs.use_sticky_comment }}
       max_output_tokens: ${{ inputs.max_output_tokens }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner: ${{ inputs.runner }}
@@ -230,6 +237,7 @@ jobs:
       aws_region: ${{ inputs.aws_region }}
       prompt: ${{ inputs.prompt }}
       sticky_namespace: ${{ inputs.sticky_namespace }}
+      use_sticky_comment: ${{ inputs.use_sticky_comment }}
       reasoning_effort: ${{ inputs.reasoning_effort }}
       max_output_tokens: ${{ inputs.max_output_tokens }}
       timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/codex-executor.yml
+++ b/.github/workflows/codex-executor.yml
@@ -89,6 +89,11 @@ on:
         required: false
         type: string
         default: ''
+      use_sticky_comment:
+        description: 'Reuse one auto-updating comment per PR (true, default). Set false to post a fresh comment on every run, preserving the full feedback->change->feedback history for reviewers.'
+        required: false
+        type: boolean
+        default: true
       max_diff_chars:
         description: 'Maximum diff length to send to the model (chars). Larger diffs are truncated at a line boundary.'
         required: false
@@ -135,6 +140,7 @@ jobs:
       REASONING_EFFORT: ${{ inputs.reasoning_effort }}
       # Default uses the model id so different models naturally get different stickies.
       STICKY_MARKER: ${{ format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
+      USE_STICKY: ${{ inputs.use_sticky_comment }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -159,8 +165,10 @@ jobs:
           cat > /tmp/sticky-comment.sh <<'STICKY_EOF'
           #!/usr/bin/env bash
           # Find-or-update a single PR comment identified by STICKY_MARKER.
+          # When USE_STICKY=false, always post a fresh comment (skip the lookup) so the
+          # full feedback->change->feedback history stays visible to reviewers.
           # Usage: sticky-comment.sh <pr_number> <body_file>
-          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER
+          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER, USE_STICKY (default true)
           set -euo pipefail
           PR_NUMBER="${1:?pr number required}"
           BODY_FILE="${2:?body file required}"
@@ -168,12 +176,16 @@ jobs:
           : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
           : "${STICKY_MARKER:?STICKY_MARKER must be set}"
           [ -r "$BODY_FILE" ] || { echo "Body file not readable: $BODY_FILE" >&2; exit 1; }
-          EXISTING_ID=$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-              | jq -r --arg marker "$STICKY_MARKER" \
-                  '.[] | select(.body | startswith($marker)) | .id' \
-              | head -1
-          )
+          if [ "${USE_STICKY:-true}" = "true" ]; then
+            EXISTING_ID=$(
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+                | jq -r --arg marker "$STICKY_MARKER" \
+                    '.[] | select(.body | startswith($marker)) | .id' \
+                | head -1
+            )
+          else
+            EXISTING_ID=""
+          fi
           if [ -n "$EXISTING_ID" ] && ! [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
             echo "::warning::EXISTING_ID is non-numeric ($EXISTING_ID); creating a new comment instead"
             EXISTING_ID=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ The matches for the Anthropic and OpenAI families are anchored: `^([a-z]+\.)?ant
 
 ### Sticky Comments
 
-- The Anthropic path's sticky comment is managed by `anthropics/claude-code-action@v1` via `use_sticky_comment: "true"`.
+- The Anthropic path's sticky comment is managed by `anthropics/claude-code-action@v1` via `use_sticky_comment`.
 - The Bedrock generic path manages its own sticky comment via an inlined find-or-update helper (written to `/tmp` at job start), keyed by a marker `<!-- dotcms-ai-review:v3:<namespace> -->`. The namespace defaults to the model family; consumers can pass `sticky_namespace` to avoid collisions when running multiple review jobs on the same PR.
+- **Disabling stickiness**: pass `use_sticky_comment: false` to the orchestrator (default `true`). When off, every run posts a fresh comment instead of updating one, preserving the full feedback→change→feedback history for reviewers. Applies to all three paths (Anthropic, Bedrock generic, Codex). On the Bedrock/Codex paths this just skips the find-existing lookup so a new comment is always created.
 
 ### Critical Architectural Insight
 


### PR DESCRIPTION
## What

Adds an optional, backwards-compatible `use_sticky_comment` boolean input (default `true`) to the orchestrator, threaded to all three executors.

When `false`, each run posts a **fresh** PR comment instead of updating a single sticky one — preserving the full `feedback → change → feedback` history that some reviewers prefer (per Wezell).

## Why

Some repos would rather keep the full review history as discrete comments than collapse it into one auto-updating comment.

## How

| Path | Change |
|------|--------|
| Orchestrator | New `use_sticky_comment` input, passed to all 3 executor calls |
| Anthropic (`claude-executor`) | Wired into `anthropics/claude-code-action@v1`'s `use_sticky_comment` (API + Bedrock steps) |
| Bedrock generic + Codex | New input + `USE_STICKY` job env; the `/tmp` sticky helper skips the find-existing lookup when `false`, so a new comment is always created |

## Backwards compatibility

Default is `true` → identical to today. Unset/empty also resolves to sticky-on (helper defaults `USE_STICKY:-true`).

## Usage

\`\`\`yaml
uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
with:
  use_sticky_comment: false   # full feedback->change->feedback history
\`\`\`

## Testing

- `yaml.safe_load` on all 4 workflows — OK
- `actionlint` 1.7.7 — clean
- Branch-logic self-check: `true`/unset → update existing, `false` → fresh comment

Closes: #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)