### PR TITLE
fix(executors): SHA-scoped marker for non-sticky comments (no orphaned in-progress)

### DIFF
--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -89,8 +89,12 @@ jobs:
       # the same PR (e.g. a backend-only review + a frontend-only review). The
       # default uses the model family so different models naturally get
       # different stickies.
-      STICKY_MARKER: ${{ format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
-      USE_STICKY: ${{ inputs.use_sticky_comment }}
+      # In non-sticky mode the marker carries the head SHA, so a re-run on the same
+      # commit updates its comment in place (in-progress -> final, no orphan) while a
+      # new commit gets a fresh comment — giving per-commit review history. In sticky
+      # mode the marker has no SHA, so one comment is updated across all commits. The
+      # trailing " -->" keeps the sticky marker from being a prefix of the SHA form.
+      STICKY_MARKER: ${{ inputs.use_sticky_comment == false && format('<!-- dotcms-ai-review:v3:{0}:{1} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id, github.event.pull_request.head.sha || github.sha) || format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,10 +116,11 @@ jobs:
           cat > /tmp/sticky-comment.sh <<'STICKY_EOF'
           #!/usr/bin/env bash
           # Find-or-update a single PR comment identified by STICKY_MARKER.
-          # When USE_STICKY=false, always post a fresh comment (skip the lookup) so the
-          # full feedback->change->feedback history stays visible to reviewers.
+          # Stickiness is encoded in the marker itself (the caller appends the head
+          # SHA in non-sticky mode), so this just find-or-updates by exact marker:
+          # same marker -> update in place, no match -> fresh comment.
           # Usage: sticky-comment.sh <pr_number> <body_file>
-          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER, USE_STICKY (default true)
+          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER
           set -euo pipefail
           PR_NUMBER="${1:?pr number required}"
           BODY_FILE="${2:?body file required}"
@@ -123,16 +128,12 @@ jobs:
           : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
           : "${STICKY_MARKER:?STICKY_MARKER must be set}"
           [ -r "$BODY_FILE" ] || { echo "Body file not readable: $BODY_FILE" >&2; exit 1; }
-          if [ "${USE_STICKY:-true}" = "true" ]; then
-            EXISTING_ID=$(
-              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-                | jq -r --arg marker "$STICKY_MARKER" \
-                    '.[] | select(.body | startswith($marker)) | .id' \
-                | head -1
-            )
-          else
-            EXISTING_ID=""
-          fi
+          EXISTING_ID=$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              | jq -r --arg marker "$STICKY_MARKER" \
+                  '.[] | select(.body | startswith($marker)) | .id' \
+              | head -1
+          )
           if [ -n "$EXISTING_ID" ] && ! [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
             echo "::warning::EXISTING_ID is non-numeric ($EXISTING_ID); creating a new comment instead"
             EXISTING_ID=""

--- a/.github/workflows/codex-executor.yml
+++ b/.github/workflows/codex-executor.yml
@@ -139,8 +139,12 @@ jobs:
       MAX_OUTPUT_TOKENS: ${{ inputs.max_output_tokens }}
       REASONING_EFFORT: ${{ inputs.reasoning_effort }}
       # Default uses the model id so different models naturally get different stickies.
-      STICKY_MARKER: ${{ format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
-      USE_STICKY: ${{ inputs.use_sticky_comment }}
+      # In non-sticky mode the marker carries the head SHA, so a re-run on the same
+      # commit updates its comment in place (in-progress -> final, no orphan) while a
+      # new commit gets a fresh comment — giving per-commit review history. In sticky
+      # mode the marker has no SHA, so one comment is updated across all commits. The
+      # trailing " -->" keeps the sticky marker from being a prefix of the SHA form.
+      STICKY_MARKER: ${{ inputs.use_sticky_comment == false && format('<!-- dotcms-ai-review:v3:{0}:{1} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id, github.event.pull_request.head.sha || github.sha) || format('<!-- dotcms-ai-review:v3:{0} -->', inputs.sticky_namespace != '' && inputs.sticky_namespace || inputs.model_id) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -165,10 +169,11 @@ jobs:
           cat > /tmp/sticky-comment.sh <<'STICKY_EOF'
           #!/usr/bin/env bash
           # Find-or-update a single PR comment identified by STICKY_MARKER.
-          # When USE_STICKY=false, always post a fresh comment (skip the lookup) so the
-          # full feedback->change->feedback history stays visible to reviewers.
+          # Stickiness is encoded in the marker itself (the caller appends the head
+          # SHA in non-sticky mode), so this just find-or-updates by exact marker:
+          # same marker -> update in place, no match -> fresh comment.
           # Usage: sticky-comment.sh <pr_number> <body_file>
-          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER, USE_STICKY (default true)
+          # Env:   GH_TOKEN, GITHUB_REPOSITORY, STICKY_MARKER
           set -euo pipefail
           PR_NUMBER="${1:?pr number required}"
           BODY_FILE="${2:?body file required}"
@@ -176,16 +181,12 @@ jobs:
           : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
           : "${STICKY_MARKER:?STICKY_MARKER must be set}"
           [ -r "$BODY_FILE" ] || { echo "Body file not readable: $BODY_FILE" >&2; exit 1; }
-          if [ "${USE_STICKY:-true}" = "true" ]; then
-            EXISTING_ID=$(
-              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-                | jq -r --arg marker "$STICKY_MARKER" \
-                    '.[] | select(.body | startswith($marker)) | .id' \
-                | head -1
-            )
-          else
-            EXISTING_ID=""
-          fi
+          EXISTING_ID=$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              | jq -r --arg marker "$STICKY_MARKER" \
+                  '.[] | select(.body | startswith($marker)) | .id' \
+              | head -1
+          )
           if [ -n "$EXISTING_ID" ] && ! [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
             echo "::warning::EXISTING_ID is non-numeric ($EXISTING_ID); creating a new comment instead"
             EXISTING_ID=""


### PR DESCRIPTION
## Problem

e2e of v3.1.7 (`use_sticky_comment: false`) on the bedrock-generic (DeepSeek R1) and codex (GPT-5.5) paths showed each run leaves a **dangling "🔄 review in progress" comment**:

| Path | final reviews (2 runs) | orphaned in-progress |
|------|------------------------|----------------------|
| bedrock-generic | 2 ✅ | 2 ❌ |
| codex | 2 ✅ | 2 ❌ |

Root cause: in non-sticky mode #48 skipped the find-existing lookup in **both** the in-progress step and the final step, so the final review posted as a *separate* comment and never reclaimed the placeholder.

## Fix

Encode stickiness in the **marker** instead of skipping the lookup:

- **Non-sticky**: marker carries the head SHA — `<!-- dotcms-ai-review:v3:<ns>:<sha> -->`. The lookup stays on, so a re-run on the same commit updates its comment in place (in-progress → final, no orphan), and a new commit produces a fresh comment → per-commit `feedback → change → feedback` history.
- **Sticky** (default): marker has no SHA — unchanged, one comment updated across all commits.

The trailing ` -->` keeps the sticky marker from being a prefix of the SHA form, so the two modes can't cross-match.

## Files

- `.github/workflows/bedrock-generic-executor.yml`
- `.github/workflows/codex-executor.yml`

(Anthropic path is unaffected — it uses `claude-code-action`'s own `use_sticky_comment`.)

## Testing

actionlint clean; prefix-collision invariant asserted. Will be validated e2e on R1 + GPT-5.5 before `@v3` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
