### PR TITLE
fix(bedrock-generic): clean up sticky comment on cancellation

### DIFF
--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -286,3 +286,25 @@ jobs:
             printf "<sub>Run: [#%s](%s)</sub>\n" "${GITHUB_RUN_ID}" "${RUN_LINK}"
           } > /tmp/comment.md
           /tmp/sticky-comment.sh "${PR_NUMBER}" /tmp/comment.md
+
+      - name: Report cancellation into sticky comment
+        # Cancellation (a newer push superseded this run, or the job timed out) is NOT failure(),
+        # so without this the sticky stays stuck on "🔄 review in progress" forever. Runs in the
+        # cancellation grace period; a single comment update fits well within it. Mirrors the
+        # codex-executor handler so both generic executors clean up cancelled runs identically.
+        if: cancelled()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Only possible once we know the PR; if cancelled before that, there's no sticky yet.
+          [ -n "${PR_NUMBER:-}" ] || exit 0
+          RUN_LINK="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            printf "%s\n\n" "${STICKY_MARKER}"
+            printf "## ⏱️ Bedrock Review canceled — \`%s\`\n\n" "${MODEL_ID}"
+            printf "The review run was canceled before completing — superseded by a newer push, or it timed out.\n\n"
+            printf "<sub>Run: [#%s](%s)</sub>\n" "${GITHUB_RUN_ID}" "${RUN_LINK}"
+          } > /tmp/comment.md
+          /tmp/sticky-comment.sh "${PR_NUMBER}" /tmp/comment.md


### PR DESCRIPTION
## Problem

`bedrock-generic-executor.yml` has no `cancelled()` handler. When a newer push cancels an in-flight review — consumers commonly set `concurrency: cancel-in-progress: true` (e.g. dotCMS/core's auto-review job) — the sticky comment stays stuck on **🔄 review in progress** forever, since cancellation is not `failure()`.

`codex-executor.yml` already handles this (`Report cancellation into sticky comment`); this brings the bedrock-generic executor to parity. Found during the e2e review of the `use_sticky_comment` work (#48/#49) — it affects both sticky and non-sticky modes equally and is the most likely real-world source of stray "in progress" comments.

## Fix

Add an `if: cancelled()` step that updates the sticky comment to a "canceled" state, mirroring the codex handler exactly (same env, same `[ -n "$PR_NUMBER" ] || exit 0` guard for cancellation-before-PR-resolution, same `/tmp/sticky-comment.sh` update).

```yaml
- name: Report cancellation into sticky comment
  if: cancelled()
  ...
  printf "## ⏱️ Bedrock Review canceled — \`%s\`\n\n" "${MODEL_ID}"
```

## Testing

actionlint clean; YAML validates. Behavior is identical to the already-shipped codex handler.

Closes: #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
