### PR TITLE
feat(bedrock-generic): carry prior review findings into the prompt

### DIFF
--- a/.github/workflows/bedrock-generic-executor.yml
+++ b/.github/workflows/bedrock-generic-executor.yml
@@ -185,6 +185,34 @@ jobs:
           fi
           echo "number=${PR_NUM}" >> "$GITHUB_OUTPUT"
 
+      # Capture the previous review's machine-data findings BEFORE the
+      # in-progress comment overwrites a sticky comment. Each review appends a
+      # `<!-- dotcms-review-findings:[...] -->` block; we carry the most recent
+      # one forward so the model can mark items Existing/Resolved instead of
+      # re-reviewing statelessly. Works for sticky (one comment) and non-sticky
+      # (per-commit comments) alike — we just take the latest block.
+      - name: Capture prior review findings
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          : > /tmp/prior-findings.md
+          FINDINGS=$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              | jq -r '[.[].body | scan("dotcms-review-findings:(\\[.*\\])\\s*-->")[0]] | last // empty'
+          )
+          if [ -n "${FINDINGS}" ] && [ "${FINDINGS}" != "[]" ]; then
+            {
+              printf '## Prior review findings (recheck these)\n\n'
+              echo "${FINDINGS}" | jq -r '.[] | "- \(.sev): `\(.loc)` — \(.desc)"'
+              printf '\n'
+            } > /tmp/prior-findings.md
+            echo "Carried forward $(echo "${FINDINGS}" | jq 'length') prior finding(s)"
+          else
+            echo "No prior findings to carry forward"
+          fi
+
       - name: Post in-progress sticky comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -230,6 +258,12 @@ jobs:
           fi
           {
             printf "%s\n\n" "${REVIEW_PROMPT}"
+            # Carried-forward findings from the previous review, if any. The
+            # prompt's "If a Prior review findings section is present" rules
+            # consume this to populate the Existing/Resolved sections.
+            if [ -s /tmp/prior-findings.md ]; then
+              cat /tmp/prior-findings.md
+            fi
             printf -- "--- BEGIN DIFF ---\n"
             cat /tmp/pr.diff
             printf -- "\n--- END DIFF ---\n"

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -1,0 +1,26 @@
+---
+# Self-review: dogfood the reviewer on ai-workflows' own PRs.
+#
+# Uses the LOCAL orchestrator (./.github/workflows/...) so a PR is reviewed by
+# the version of the workflows it itself proposes — changes to the executors
+# are exercised before they ship. model_id is pinned to a non-Anthropic Bedrock
+# model so it routes through bedrock-generic-executor. Requires the org-level
+# BEDROCK_ROLE_ARN variable and that role's OIDC trust to permit this repo.
+
+name: Self Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  claude-automatic-review:
+    uses: ./.github/workflows/claude-orchestrator.yml
+    with:
+      model_id: qwen.qwen3-next-80b-a3b
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
+      trigger_mode: automatic
+      prompt: ${{ vars.AI_REVIEWER_PROMPT }}
+      use_sticky_comment: false
+      enable_mention_detection: false
+    secrets: inherit

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -1,11 +1,10 @@
 ---
-# Self-review: dogfood the reviewer on ai-workflows' own PRs.
+# Self-review: run the reviewer on ai-workflows' own PRs.
 #
-# Uses the LOCAL orchestrator (./.github/workflows/...) so a PR is reviewed by
-# the version of the workflows it itself proposes — changes to the executors
-# are exercised before they ship. model_id is pinned to a non-Anthropic Bedrock
-# model so it routes through bedrock-generic-executor. Requires the org-level
-# BEDROCK_ROLE_ARN variable and that role's OIDC trust to permit this repo.
+# Pinned to the released @v3 orchestrator (same as consumer repos). model_id is
+# a non-Anthropic Bedrock model so it routes through bedrock-generic-executor.
+# Requires the org-level BEDROCK_ROLE_ARN variable and that role's OIDC trust to
+# permit this repo.
 
 name: Self Review
 
@@ -15,7 +14,7 @@ on:
 
 jobs:
   claude-automatic-review:
-    uses: ./.github/workflows/claude-orchestrator.yml
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       model_id: qwen.qwen3-next-80b-a3b
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}


### PR DESCRIPTION
## Problem
The bedrock-generic reviewer is **stateless** — each run feeds the model only `gh pr diff` (current diff vs base), with no memory of prior runs. The `gpt-auto-review` prompt describes an Existing/Resolved/"Prior review findings" protocol, but the executor never supplied that data, so the model **confabulated** those sections (e.g. "✅ Resolved: previously flagged" with no actual prior data).

## Fix
- **Capture** the most recent review comment's `<!-- dotcms-review-findings:[...] -->` machine block (new step, runs *before* the in-progress comment overwrites a sticky one).
- **Inject** it into the prompt as the `## Prior review findings (recheck these)` section the prompt already knows how to consume.
- Works for sticky (one comment) and non-sticky (per-commit) modes — takes the latest block. No-op when there are no prior findings.

## Result
Existing/Resolved tracking becomes real: fixed items show under **Resolved**, unfixed ones under **Existing**, against an actual prior-findings list instead of the model's imagination.

Verified the extraction jq against a live multi-round PR and actionlint (CI image) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)