### PR TITLE
test: agentic harness smoke (DO NOT MERGE)

### DIFF
--- a/scripts/_smoke_input.py
+++ b/scripts/_smoke_input.py
@@ -1,0 +1,7 @@
+# Throwaway smoke fixture for the agentic reviewer. DO NOT MERGE.
+import os
+
+
+def pr_supplied_ref() -> str:
+    # Attacker-controlled: the PR-supplied ref/title arrives via the environment.
+    return os.environ.get("PR_REF", "")

--- a/scripts/_smoke_runner.py
+++ b/scripts/_smoke_runner.py
@@ -1,0 +1,9 @@
+# Throwaway smoke fixture for the agentic reviewer. DO NOT MERGE.
+import subprocess
+
+from _smoke_input import pr_supplied_ref
+
+
+def show_ref_log() -> None:
+    ref = pr_supplied_ref()
+    subprocess.run("git log " + ref, shell=True)

--- a/scripts/_smoke_runner.py
+++ b/scripts/_smoke_runner.py
@@ -7,3 +7,5 @@ from _smoke_input import pr_supplied_ref
 def show_ref_log() -> None:
     ref = pr_supplied_ref()
     subprocess.run("git log " + ref, shell=True)
+
+# (smoke: re-run on beta.4)

--- a/scripts/_smoke_runner.py
+++ b/scripts/_smoke_runner.py
@@ -9,3 +9,5 @@ def show_ref_log() -> None:
     subprocess.run("git log " + ref, shell=True)
 
 # (smoke: re-run on beta.4)
+
+# (smoke: re-run on beta.5 dedup)


### PR DESCRIPTION
Throwaway PR to exercise the agentic harness (`v3.3.0-beta.3`) end-to-end.

Planted a **cross-file command injection**: `_smoke_runner.py` runs `subprocess.run("git log " + ref, shell=True)` where `ref` comes from `_smoke_input.pr_supplied_ref()` (env-derived, attacker-controlled) in a **different file**.

Expected from the reviewer:
- Stage 1 flags a candidate in `_smoke_runner.py`.
- Stage 2 reads `_smoke_input.py` to confirm the taint → **confirmed Critical/High**.
- An **inline comment** lands on the `subprocess.run` line.
- The **severity gate fails the check** (red ✗).

Base is the feature branch so self-review.yml runs the beta harness.