### PR TITLE
docs: update consumer examples to @v3 + Bedrock (no API key) + structured prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you previously used the pilot Claude workflow in `dotcms/infrastructure-as-co
    ```yaml
    jobs:
      claude:
-       uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+       uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
        with:
          trigger_mode: automatic  # or 'interactive' for @claude mentions
          # Customize as needed for your repo
@@ -78,7 +78,9 @@ If you previously used the pilot Claude workflow in `dotcms/infrastructure-as-co
          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
    ```
 
-   ⚠️ **Important**: Always use version tags (e.g., `@v1.0.0`) instead of `@main` for production stability. Using `@main` can cause unexpected behavior when the main branch is updated.
+   ⚠️ **Important**: Always use the floating major tag (e.g., `@v3`) instead of `@main` for production stability. Using `@main` can cause unexpected behavior when the main branch is updated.
+
+   > **Current setup (v3+):** reviews run on **AWS Bedrock**. Set `BEDROCK_MODEL_ID` and `BEDROCK_ROLE_ARN` as repo/org variables — **no `ANTHROPIC_API_KEY` secret is required**. The `ANTHROPIC_API_KEY` references below are legacy. For an up-to-date, copy-pasteable setup see [`examples/consumer-repo-workflow.yml`](./examples/consumer-repo-workflow.yml) and [`examples/infrastructure-consumer-workflow.yml`](./examples/infrastructure-consumer-workflow.yml), which are the canonical reference.
 
 3. **Configure your `ANTHROPIC_API_KEY` secret** as described below.
 4. **(Optional) Customize prompts, allowed tools, and runner as needed.**
@@ -230,7 +232,7 @@ jobs:
         contains(github.event.pull_request.body, '@Claude') ||
         contains(github.event.pull_request.body, '@CLAUDE')
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       trigger_mode: interactive
       allowed_tools: |
@@ -243,7 +245,7 @@ jobs:
   # Automatic PR reviews (orchestrator skips when @claude mention exists by default)
   claude-automatic:
     if: github.event_name == 'pull_request'
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       trigger_mode: automatic
       direct_prompt: |
@@ -277,7 +279,7 @@ For advanced use cases beyond @claude mentions, use `custom_trigger_condition`:
 ```yaml
 jobs:
   claude-security-review:
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       trigger_mode: automatic
       custom_trigger_condition: |
@@ -330,7 +332,7 @@ See the `examples/` directory for complete workflow examples:
 
 **Basic @claude mention detection:**
 ```yaml
-uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
 with:
   trigger_mode: interactive
   enable_mention_detection: true
@@ -338,7 +340,7 @@ with:
 
 **Automatic PR reviews:**
 ```yaml
-uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
 with:
   trigger_mode: automatic
   direct_prompt: "Review this PR for quality and security."
@@ -347,7 +349,7 @@ with:
 
 **Custom triggers for urgent issues:**
 ```yaml
-uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
 with:
   trigger_mode: interactive
   custom_trigger_condition: |
@@ -411,11 +413,11 @@ This repository is designed for both internal dotCMS use and external sharing:
 
 ### Version Tags
 
-**Always use version tags** (`@v1.0.0`) instead of `@main` for production stability:
+**Always use a version tag** (`@v3`) instead of `@main` for production stability:
 
 ```yaml
 # ✅ Production-safe
-uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
 
 # ❌ Unstable - avoid for production
 uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@main

--- a/examples/consumer-repo-workflow.yml
+++ b/examples/consumer-repo-workflow.yml
@@ -1,5 +1,10 @@
 # Example workflow for a consumer repository
 # This file should be placed in .github/workflows/ in the consuming repository
+#
+# MODEL: reviews run on AWS Bedrock. Set the model via the repo/org variable
+# BEDROCK_MODEL_ID and the IAM role via BEDROCK_ROLE_ARN. The orchestrator routes
+# by model id: anthropic.* -> Claude, openai.* -> Bedrock-mantle (codex), everything
+# else -> bedrock-generic (Converse). No ANTHROPIC_API_KEY needed.
 
 name: Claude AI Integration
 
@@ -40,8 +45,10 @@ jobs:
         contains(github.event.pull_request.body, '@Claude') ||
         contains(github.event.pull_request.body, '@CLAUDE')
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
+      model_id: ${{ vars.BEDROCK_MODEL_ID }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: interactive
       claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
@@ -49,24 +56,37 @@ jobs:
       enable_mention_detection: true  # Uses built-in @claude mention detection
       # custom_trigger_condition: |    # Optional: Override default mention detection
       #   your custom condition here
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
     if: github.event_name == 'pull_request'
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
+      model_id: ${{ vars.BEDROCK_MODEL_ID }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
+      # Terse, structured review prompt. One line per finding, severity + file:line,
+      # no essays. Mirrors the format proven in dotCMS/core's automatic review.
       prompt: |
-        Please review this pull request and provide feedback on:
-        - Code quality and best practices
-        - Potential bugs or issues
-        - Performance considerations
-        - Security concerns
-        - Test coverage
+        You are reviewing a pull request. Review only what's in the diff. Be direct
+        and specific — include file and line for every finding. Skip praise, summaries,
+        and style nitpicks. Do not invent issues. Only flag problems this PR introduces.
 
-        Be constructive and helpful in your feedback.
+        Check for:
+        1. **Bugs** — logic errors, null/undefined deref, off-by-one, missing edge
+           cases, race conditions
+        2. **Security** — injection, missing authz checks, secrets in code or logs,
+           unvalidated input used in paths or system calls
+        3. **Error paths** — for each external call or state change, what happens when
+           it fails? Caught, logged, surfaced, or silently swallowed?
+        4. **Missing code** — no timeout, no rollback, no error handler, no test for
+           the failure case. Half of bugs are a correct line never written.
+        5. **Test gaps** — meaningful new behavior with no coverage
+
+        Format each finding as a single line, severity first:
+        🔴 **Critical** / 🟠 **High** / 🟡 **Medium** `path/file:line` — what's wrong and why it matters
+
+        🔴/🟠 are blocking; 🟡 is non-blocking. If the PR is clean, say so in one sentence.
       claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
@@ -74,5 +94,3 @@ jobs:
       # skip_automatic_when_mentioned: false  # Optional: allow automatic mode even with @claude mention
       # custom_trigger_condition: |     # Optional: Custom trigger logic
       #   your custom condition here
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/infrastructure-consumer-workflow.yml
+++ b/examples/infrastructure-consumer-workflow.yml
@@ -2,6 +2,13 @@
 # Infrastructure-as-Code Consumer Workflow Example
 # This example shows how to configure Claude workflows for infrastructure repositories
 # with Terraform, Terragrunt, and Kubernetes-specific tooling.
+#
+# MODEL: chosen by the repo var AI_REVIEW_MODEL_ID (falls back to the org/repo
+# BEDROCK_MODEL_ID). It's a *repo* var on purpose — tuning it changes only this
+# repo's review model without touching the org var the rest of the fleet shares.
+# The orchestrator routes by id: anthropic.* -> Claude, openai.* -> Bedrock-mantle
+# (codex), everything else -> bedrock-generic. Reviews run on Bedrock via
+# BEDROCK_ROLE_ARN — no ANTHROPIC_API_KEY needed.
 
 name: Infrastructure AI Checks
 
@@ -47,8 +54,10 @@ jobs:
         contains(github.event.pull_request.body, '@Claude') ||
         contains(github.event.pull_request.body, '@CLAUDE')
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
+      model_id: ${{ vars.AI_REVIEW_MODEL_ID || vars.BEDROCK_MODEL_ID }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: interactive
       claude_args: '--allowedTools "Bash(terraform validate),Bash(terraform plan),Bash(terraform fmt),Bash(terragrunt validate),Bash(terragrunt plan),Bash(terragrunt hclfmt),Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
@@ -56,28 +65,40 @@ jobs:
       enable_mention_detection: true  # Uses built-in @claude mention detection
       # custom_trigger_condition: |    # Optional: Custom trigger logic
       #   github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'infrastructure')
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # Automatic PR reviews (orchestrator skips when @claude mention is present by default)
   claude-automatic-review:
     if: github.event_name == 'pull_request'
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
+      model_id: ${{ vars.AI_REVIEW_MODEL_ID || vars.BEDROCK_MODEL_ID }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
+      # Terse, structured review prompt tuned for IaC. One line per finding,
+      # severity + file:line, no essays. Mirrors dotCMS/core's review format.
       prompt: |
-        Please review this infrastructure-as-code pull request and provide feedback on:
-        - Code quality and best practices
-        - Potential bugs or issues
-        - Performance considerations
-        - Security concerns
-        - Test coverage
-        - Estimated cost spend or savings of the changes
-        - Terraform/Terragrunt best practices
-        - Resource naming conventions
-        - Infrastructure security implications
+        You are reviewing a pull request for **infrastructure-as-code**
+        (Terraform + Terragrunt on AWS, Kubernetes manifests, GitHub Actions workflows).
 
-        Be constructive and helpful in your feedback.
+        Review only what's in the diff. Be direct and specific — include file and line
+        for every finding. Skip praise, summaries, and style nitpicks. Do not invent issues.
+
+        Check for:
+        1. **Bugs** — wrong resource refs/interpolations, count/for_each errors, missing
+           depends_on, broken module inputs/outputs
+        2. **Security** — overly permissive IAM (wildcard actions/resources/principals),
+           open ingress (0.0.0.0/0), unencrypted or public storage, plaintext secrets
+        3. **State & blast radius** — changes that force replace or destroy/recreate,
+           drift risks, missing lifecycle guards on shared/stateful resources
+        4. **Cost** — sizing, always-on resources, NAT/data-transfer, anything that
+           materially moves spend
+        5. **IaC conventions** — Terraform/Terragrunt best practices, pinned
+           provider/module versions, consistent resource naming
+
+        Format each finding as a single line, severity first:
+        🔴 **Critical** / 🟠 **High** / 🟡 **Medium** `path/to/file:line` — what's wrong and why it matters
+
+        🔴/🟠 are blocking; 🟡 is non-blocking. If the PR is clean, say so in one sentence.
       claude_args: '--allowedTools "Bash(terraform validate),Bash(terraform plan),Bash(terraform fmt),Bash(terragrunt validate),Bash(terragrunt plan),Bash(terragrunt hclfmt),Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
@@ -85,5 +106,3 @@ jobs:
       # skip_automatic_when_mentioned: false  # Optional: allow automatic mode even with @claude mention
       # custom_trigger_condition: |     # Optional: Custom logic for infrastructure changes
       #   github.event_name == 'pull_request' && contains(github.event.pull_request.body, 'terraform')
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## What

Brings the ai-workflows consumer **examples** (and the README's stale snippets) up to the current v3 standard, and backports the terse structured review prompt that's been proven in `dotCMS/core`.

### Examples (the canonical copy-paste artifacts)
Both `examples/consumer-repo-workflow.yml` and `examples/infrastructure-consumer-workflow.yml`:
- **Float to `@v3`** (was `@v2.0.0`) so consumers track patch releases automatically
- **Add Bedrock wiring**: `model_id: ${{ vars.BEDROCK_MODEL_ID }}` + `bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}`
- **Drop `ANTHROPIC_API_KEY`** secrets blocks — reviews run on Bedrock via the IAM role; the key is vestigial
- **Modern terse, structured review prompt** — one line per finding, severity + `file:line`, no essays (mirrors `core`'s `.github/prompts/gpt-auto-review.md`). The infra example uses the IaC-flavored variant (bugs / security / state & blast radius / cost / IaC conventions).
- The infra example demonstrates the **repo-var override** pattern: `${{ vars.AI_REVIEW_MODEL_ID || vars.BEDROCK_MODEL_ID }}`.

### README
- Bumped all orchestrator pins `@v1.0.0`/`@v2.0.0` → `@v3`
- Added a callout: Bedrock + `@v3`, no `ANTHROPIC_API_KEY` required, examples are canonical

## Why
The examples are what consuming repos copy. They were 2 majors behind (old `@v1/@v2`, `allowed_tools`/`direct_prompt` input names, required API key) while `core`/`platform`/IaC moved to `@v3` + Bedrock-via-role + structured prompts. This closes that gap so new consumers start on the current pattern.

## Follow-up (not in this PR)
The README still has ~15 stale references in its **prose, inputs table, and inline snippets** (`direct_prompt`/`allowed_tools` multi-line blocks that can't be safely sed-renamed). Left for a focused doc-rewrite rather than half-editing it into broken YAML — the examples are now the authoritative reference.
