### PR TITLE
fix(pricing): add Sonnet 4.6 to the per-model price table

### DIFF
--- a/.github/workflows/bedrock-harness-executor.yml
+++ b/.github/workflows/bedrock-harness-executor.yml
@@ -686,11 +686,12 @@ jobs:
           # Bedrock pricing; correct/extend per-run via the `model_prices` input (authoritative).
           # Unknown model => cost omitted (never guessed in the footer). Shown with a leading "~".
           PRICES = {
-              "us.anthropic.claude-opus-4-8": (15.0, 75.0),
-              "us.deepseek.r1-v1:0":          (1.35, 5.40),
-              "qwen.qwen3-next-80b-a3b":      (0.40, 1.60),
-              "zai.glm-5":                    (0.60, 2.20),
-              "openai.gpt-5.5":               (1.25, 10.0),
+              "us.anthropic.claude-opus-4-8":   (15.0, 75.0),
+              "us.anthropic.claude-sonnet-4-6": (3.0, 15.0),
+              "us.deepseek.r1-v1:0":            (1.35, 5.40),
+              "qwen.qwen3-next-80b-a3b":        (0.40, 1.60),
+              "zai.glm-5":                      (0.60, 2.20),
+              "openai.gpt-5.5":                 (1.25, 10.0),
           }
           raw_prices = os.environ.get("MODEL_PRICES", "").strip()
           if raw_prices:

--- a/.github/workflows/codex-executor.yml
+++ b/.github/workflows/codex-executor.yml
@@ -456,11 +456,12 @@ jobs:
           # Estimated run cost (USD per 1M tokens; APPROXIMATE — verify vs AWS/mantle pricing,
           # override via the model_prices input). Unknown model => cost omitted, never guessed.
           PRICES = {
-              "us.anthropic.claude-opus-4-8": (15.0, 75.0),
-              "us.deepseek.r1-v1:0":          (1.35, 5.40),
-              "qwen.qwen3-next-80b-a3b":      (0.40, 1.60),
-              "zai.glm-5":                    (0.60, 2.20),
-              "openai.gpt-5.5":               (1.25, 10.0),
+              "us.anthropic.claude-opus-4-8":   (15.0, 75.0),
+              "us.anthropic.claude-sonnet-4-6": (3.0, 15.0),
+              "us.deepseek.r1-v1:0":            (1.35, 5.40),
+              "qwen.qwen3-next-80b-a3b":        (0.40, 1.60),
+              "zai.glm-5":                      (0.60, 2.20),
+              "openai.gpt-5.5":                 (1.25, 10.0),
           }
           _raw_prices = os.environ.get("MODEL_PRICES", "").strip()
           if _raw_prices:


### PR DESCRIPTION
Sonnet 4.6 was missing from the cost-footer price table, so its reviews showed no estimated cost. Adds `us.anthropic.claude-sonnet-4-6` at $3/$15 per 1M tokens (in/out) on both harness + codex paths. Approximate, overridable via `model_prices`. Patch → v3.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)