### PR TITLE
fix(bedrock-harness): stop dropping reasoning-model findings (DeepSeek R1)

### DIFF
--- a/.github/workflows/bedrock-harness-executor.yml
+++ b/.github/workflows/bedrock-harness-executor.yml
@@ -406,21 +406,36 @@ jobs:
 
           ACTION_RE = re.compile(r"<action>\s*(\{.*?\})\s*</action>", re.DOTALL)
 
+          # Reasoning models (DeepSeek R1, etc.) prefix a <think>…</think> chain-of-thought,
+          # often containing stray [ ] that wreck the brace-slice below. Strip it, plus any
+          # ```json fences, before extraction.
+          THINK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.DOTALL | re.IGNORECASE)
+          FENCE_RE = re.compile(r"^```[a-zA-Z]*\s*|\s*```$", re.MULTILINE)
+
           def _slice_json(text, kind):
               # Lenient extraction: whole-string parse, else the first balanced-ish [..]/{..} span.
-              text = (text or "").strip()
+              text = THINK_RE.sub("", text or "")
+              text = FENCE_RE.sub("", text).strip()
               try:
-                  return json.loads(text)
+                  data = json.loads(text)
               except json.JSONDecodeError:
-                  pass
-              o, c = ("[", "]") if kind == "array" else ("{", "}")
-              i, j = text.find(o), text.rfind(c)
-              if i != -1 and j > i:
-                  try:
-                      return json.loads(text[i:j + 1])
-                  except json.JSONDecodeError:
+                  o, c = ("[", "]") if kind == "array" else ("{", "}")
+                  i, j = text.find(o), text.rfind(c)
+                  data = None
+                  if i != -1 and j > i:
+                      try:
+                          data = json.loads(text[i:j + 1])
+                      except json.JSONDecodeError:
+                          return None
+                  else:
                       return None
-              return None
+              # When an array is expected but the model wrapped it in an object
+              # ({"candidates":[...]}, {"findings":[...]}, …), unwrap the first list value.
+              if kind == "array" and isinstance(data, dict):
+                  for v in data.values():
+                      if isinstance(v, list):
+                          return v
+              return data
 
           def ask_json(system_text, user_text, kind="array", max_tokens=MAX_OUT):
               # One forced-JSON turn with a single repair retry. This is the root fix for the old
@@ -520,6 +535,30 @@ jobs:
               except (TypeError, ValueError):
                   return 0.5
 
+          # Reasoning models paraphrase the schema keys (issue/description/reason/… instead of
+          # title/hypothesis), which used to make _usable() silently drop every candidate. Map
+          # the common aliases back onto the canonical keys at ingestion so paraphrased findings
+          # survive and render.
+          TITLE_ALIASES = ("title", "issue", "summary", "name", "problem", "finding", "message")
+          HYPO_ALIASES = ("hypothesis", "description", "reason", "detail", "details",
+                          "explanation", "rationale", "why")
+
+          def _usable(c):
+              return bool(str(c.get("title", "")).strip() or str(c.get("hypothesis", "")).strip())
+
+          def _norm_keys(c):
+              if not str(c.get("title", "")).strip():
+                  for k in TITLE_ALIASES:
+                      if str(c.get(k, "")).strip():
+                          c["title"] = c[k]
+                          break
+              if not str(c.get("hypothesis", "")).strip():
+                  for k in HYPO_ALIASES:
+                      if str(c.get(k, "")).strip():
+                          c["hypothesis"] = c[k]
+                          break
+              return c
+
           candidates = []
           for path, seg in segments:
               arr = ask_json(sys1, f"File: {path}\n\nDiff (DATA):\n{seg[:20000]}" + PR_CTX, "array") or []
@@ -528,8 +567,13 @@ jobs:
                   for c in arr:
                       if isinstance(c, dict):
                           c["file"] = path
-                          candidates.append(c)
+                          candidates.append(_norm_keys(c))
                           n += 1
+                  # Surface the model's actual keys when nothing was usable, so a new
+                  # schema-paraphrase shows up in the log instead of a silent 0.
+                  if n and not any(_usable(c) for c in candidates if c.get("file") == path):
+                      seen = sorted({k for c in arr if isinstance(c, dict) for k in c})
+                      print(f"stage1 {path}: {n} parsed but unusable; keys={seen}", file=sys.stderr)
               print(f"stage1 {path}: {n} candidate(s)", file=sys.stderr)
 
           # Drop ONLY degenerate candidates (no title AND no hypothesis) so a model that emits
@@ -538,8 +582,6 @@ jobs:
           # real candidates all below 0.3 and the old `>= CONF_MIN` filter silently nuked every one
           # (0 findings on a PR with real bugs). Volume is bounded by dedup + CAND_CAP + verify-
           # gating instead; confidence is still used only to LABEL Medium/Low confirmed-vs-advisory.
-          def _usable(c):
-              return bool(str(c.get("title", "")).strip() or str(c.get("hypothesis", "")).strip())
           candidates = [c for c in candidates if _usable(c)]
           candidates = dedupe(candidates)  # collapse the same issue raised from multiple files
           candidates.sort(key=lambda c: SEV_RANK.get(str(c.get("severity", "")).lower(), 4))

--- a/.github/workflows/bedrock-harness-executor.yml
+++ b/.github/workflows/bedrock-harness-executor.yml
@@ -535,18 +535,30 @@ jobs:
               except (TypeError, ValueError):
                   return 0.5
 
-          # Reasoning models paraphrase the schema keys (issue/description/reason/… instead of
-          # title/hypothesis), which used to make _usable() silently drop every candidate. Map
-          # the common aliases back onto the canonical keys at ingestion so paraphrased findings
-          # survive and render.
-          TITLE_ALIASES = ("title", "issue", "summary", "name", "problem", "finding", "message")
-          HYPO_ALIASES = ("hypothesis", "description", "reason", "detail", "details",
+          # Reasoning models paraphrase the schema keys, which used to make _usable() silently
+          # drop every candidate. In particular they often echo the carry-forward findings schema
+          # (sev/loc/desc) seen in the prompt instead of the stage-1 schema (severity/line/title/
+          # hypothesis). Map the common aliases back onto the canonical keys at ingestion so
+          # paraphrased findings survive and render.
+          TITLE_ALIASES = ("title", "issue", "summary", "name", "problem", "finding", "message", "desc")
+          HYPO_ALIASES = ("hypothesis", "description", "desc", "reason", "detail", "details",
                           "explanation", "rationale", "why")
+          SEV_WORDS = ("critical", "high", "medium", "low")
 
           def _usable(c):
               return bool(str(c.get("title", "")).strip() or str(c.get("hypothesis", "")).strip())
 
           def _norm_keys(c):
+              # sev ("🔴 Critical") -> severity ("Critical"); the gate/rank downstream lowercase it.
+              if not str(c.get("severity", "")).strip() and c.get("sev"):
+                  m = [w for w in SEV_WORDS if w in str(c.get("sev")).lower()]
+                  if m:
+                      c["severity"] = m[0].capitalize()
+              # loc ("path/File.java:597") -> line (int) when no explicit line was given.
+              if c.get("line") in (None, "") and c.get("loc"):
+                  mt = re.search(r":(\d+)\s*$", str(c.get("loc")))
+                  if mt:
+                      c["line"] = int(mt.group(1))
               if not str(c.get("title", "")).strip():
                   for k in TITLE_ALIASES:
                       if str(c.get(k, "")).strip():


### PR DESCRIPTION
## Symptom

The agentic Bedrock reviewer (harness path) posts **"✅ No issues found"** on PRs that have real issues — seen on at least 3 PRs, all using `us.deepseek.r1-v1:0`.

Run logs show the model **did** find candidates, which were then dropped:

```
stage1 dotCMS/pom.xml: 3 candidate(s)
stage1 .../logging.properties: 1 candidate(s)
outcome: ok; files: 3; candidates: 0; confirmed: 0; ...   # ← 4 found, 0 survive
```
(dotCMS/core #36076; #36332 shows the same: `5 candidate(s)` → `candidates: 0`.)

## Root cause

DeepSeek R1 is a reasoning model. Two things broke the harness, which was tuned on non-reasoning models (qwen, nova):

1. **`<think>` chain-of-thought** precedes the JSON and contains stray `[ ]`, wrecking `_slice_json`'s first-`[`/last-`]` brace slice.
2. **Schema paraphrasing** — R1 emits `issue`/`description`/`reason` instead of `title`/`hypothesis`, so `_usable()` (which requires `title` or `hypothesis`) silently dropped every candidate.

## Fix

- `_slice_json`: strip `<think>…</think>` and ```` ```json ```` fences before extraction; unwrap an array wrapped in an object (`{"candidates":[...]}`).
- Stage-1 ingestion: map common aliases (`issue`/`summary`/`description`/`reason`/…) onto `title`/`hypothesis` so paraphrased findings survive and render.
- Diagnostic: when parsed candidates are still unusable, log the model's actual keys — a new paraphrase shows up in the log instead of a silent `0`.

Model-agnostic; no per-model config. Non-reasoning models are unaffected (no `<think>`, schema already matches).

## Validation

- `actionlint` clean, YAML parses, embedded script `py_compile`s.
- Simulated an R1-style response (think block w/ stray brackets + fenced + paraphrased keys) through the patched parser: 2/2 candidates now survive where both were previously dropped. Wrapper-object and plain-array cases verified.
- **Not** yet e2e-tested against live R1 (per `CLAUDE.md`, that needs a sandbox tag). Recommend re-running one of the affected PRs against an `-rc` tag to confirm before consumers bump their pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
